### PR TITLE
Use official rules_scala 7.1.1 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,13 +21,8 @@ register_toolchains(
 
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
-# https://github.com/bazelbuild/rules_scala/issues/1482
-bazel_dep(name = "rules_scala", repo_name = "io_bazel_rules_scala")
-git_override(
-    module_name = "rules_scala",
-    commit      = "50fe91e5ab238a58d30d573125469a489454b1c0",
-    remote      = "https://github.com/mbland/rules_scala",
-)
+# Use the latest official release of rules_scala
+bazel_dep(name = "rules_scala", version = "7.1.1", repo_name = "io_bazel_rules_scala")
 
 scala_config = use_extension(
     "@io_bazel_rules_scala//scala/extensions:config.bzl",


### PR DESCRIPTION
## Summary
- switch to rules_scala v7.1.1 official release instead of preview commit

## Testing
- `bazel mod tidy --lockfile_mode=update` *(fails: Failed to fetch registry file https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.1/MODULE.bazel: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*
- `bazel test //...` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" while fetching https://bcr.bazel.build/modules/rules_scala/7.1.1/MODULE.bazel)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d9e48494832fa9b613d1fd87aa92